### PR TITLE
Renamed RocketRaid variables

### DIFF
--- a/build_scripts/oot-driver-variables.sh
+++ b/build_scripts/oot-driver-variables.sh
@@ -1,18 +1,6 @@
 #!/bin/bash
 set -e
 
-##current RocketRaid R750 Release - See http://www.highpoint-tech.com/BIOS_Driver/R750/Linux/
-export ROCKET="1.2.11-18_06_26"
-export ROCKETSHORT=$(echo $ROCKET | cut -d"-" -f1)
-
-##current RocketRaid RR3740A Release
-export RR="1.19.0_19_04_04"
-export RRSHORT=$(echo $RR | cut -d"-" -f1)
-
-##current RocketNVMe Driver - See http://www.highpoint-tech.com/USA_new/series-ssd7101a-1-download.htm
-export RN="1.2.16_19_05_06"
-export RNSHORT=$(echo $RN | cut -d"-" -f1)
-
 ##current Intel IXGB - See https://sourceforge.net/projects/e1000/files/igb%20stable/
 export IXGB="5.3.5.42"
 
@@ -24,17 +12,39 @@ export IXGBE_INTEL_NUMBER="14687"
 export IXGBEVF="4.5.1"
 export IXGBEVF_INTEL_NUMBER="28521"
 
-##tehuti Driver
-export TEHUTI="0.3.6.17.2"
+##current Realtek r8125 Driver
+echo -e "${BLUE}Variables.sh${NC}    -----    current Realtek r8125 Driver"
+export REALTEK="9.003.05"
 
-##Realtek r8125 Driver
-export REALTEK="9.002.02"
+##current RocketRaid RR272x Release - See https://highpoint-tech.com/USA_new/rr272x_download.htm
+echo -e "${BLUE}Variables.sh${NC}    -----    current RocketRaid RR272x Release - See https://highpoint-tech.com/USA_new/rr272x_download.htm/"
+export R272X="1.10.6_19_12_05"
+export R272XSHORT=$(echo $R272X | cut -d"-" -f1)
+
+##current RocketRaid RR3740A Release
+echo -e "${BLUE}Variables.sh${NC}    -----    current RocketRaid RR3740A Release - "
+export R3740A="1.19.0_19_04_04"
+export R3740ASHORT=$(echo $R3740A | cut -d"-" -f1)
+
+##current RocketRaid R750 Release - See http://www.highpoint-tech.com/BIOS_Driver/R750/Linux/
+echo -e "${BLUE}Variables.sh${NC}    -----    current RocketRaid R750 Release - See http://www.highpoint-tech.com/BIOS_Driver/R750/Linux/"
+export R750="1.2.11-18_06_26"
+export R750SHORT=$(echo $R750 | cut -d"-" -f1)
+
+##current RocketNVMe Driver - See http://www.highpoint-tech.com/USA_new/series-ssd7101a-1-download.htm
+echo -e "${BLUE}Variables.sh${NC}    -----    current RocketNVMe Release - "
+export RNVME="1.2.16_19_05_06"
+export RNVMESHORT=$(echo $RNVME | cut -d"-" -f1)
+
+##current Tehuti Driver
+echo -e "${BLUE}Variables.sh${NC}    -----    current Tehuti 10GB Driver"
+export TEHUTI="0.3.6.17.2"
 
 
 declare -A oot_driver_map=(
-    	  ["6.6.6"]="ixgbe"
+    	["6.6.6"]="ixgbe"
         ["6.6.7"]="ixgbe"
-    	  ["6.7.0"]="ixgbe,tehuti"
+    	["6.7.0"]="ixgbe,tehuti"
         ["6.7.1"]="ixgbe,tehuti"
         ["6.7.2"]="ixgbe,tehuti"
         ["6.7.3-rc4"]="ixgbe,tehuti"
@@ -50,7 +60,8 @@ declare -A oot_driver_map=(
         ["6.8.1"]="ixgbe,realtek,rocketnvme,rocketraid,rr3740a,tehuti,wireguard,wireguard-tools"
         ["6.8.2"]="igb,ixgbe,realtek,rocketnvme,rocketraid,rr3740a,tehuti"
         ["6.8.3"]="igb,ixgbe,realtek,rocketnvme,rocketraid,rr3740a,tehuti"
-        ["6.9.0-beta1"]=""
+        ["6.9.0-beta22"]=""
+        ["6.9.0-beta25"]="rr272x,realtek"
 )
 
 export OOT_DRIVERS="${oot_driver_map[$UNRAID_VERSION]}"


### PR DESCRIPTION
Was getting way too confusing with the rocket raid versions, so renamed according to model number